### PR TITLE
Fixed weekends not being bound to any of the events.

### DIFF
--- a/src/bootstrap.calendar.js
+++ b/src/bootstrap.calendar.js
@@ -213,7 +213,7 @@
                     ){
                         cls = "today";
                     }else if(j%7 == 0 || j%7 == 6){
-                        cls = "weekend";
+                        cls = "day weekend";
                     }else{
                         cls = "day";
                     }


### PR DESCRIPTION
Because the .day class was missing from weekends, none of the events worked on weekends. By adding the day class we can still use the events as well as styling weekends differently if we want.
