### PR TITLE
Use Bootstrap3/Glyphicons chevrons

### DIFF
--- a/src/bootstrap.calendar.js
+++ b/src/bootstrap.calendar.js
@@ -47,9 +47,9 @@
                             '<thead class="calendar-header"></thead>'+
                             '<tbody class="calendar-body"></tbody>'+
                             '<tfoot>'+
-                                '<th colspan="2" class="sel" id="last"><div class="arrow"><i class="icon-arrow-left"></i></div></th>'+
+                                '<th colspan="2" class="sel" id="last"><div class="arrow"><i class="glyphicon glyphicon-chevron-left"></i></div></th>'+
                                 '<th colspan="3" class="sel" id="current">%msg_today%</th>'+
-                                '<th colspan="2" class="sel" id="next"><div class="arrow"><i class="icon-arrow-right"></i></div></th>'+
+                                '<th colspan="2" class="sel" id="next"><div class="arrow"><i class="glyphicon glyphicon-chevron-right"></i></div></th>'+
                             '</tfoot>'+
                         '</table>'+
                     '',


### PR DESCRIPTION
Fixes the only incompatibility (which I'm aware of) with Bootstrap 3.
![](http://i.imgur.com/OheWInb.png)
